### PR TITLE
Add Examples link to Tutorial

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -6,6 +6,8 @@ The following page is also helpful if you use Sparkfun Pro Micro RP2040:
 
 [https://learn.sparkfun.com/tutorials/pro-micro-rp2040-hookup-guide](https://learn.sparkfun.com/tutorials/pro-micro-rp2040-hookup-guide)
 
+See [[Microcontroller-boards-and-Keyboards]] for other available microcontroller boards and keyboards.
+
 ## Let's try it!
 
 - Download the newest release binary from [Releases](https://github.com/picoruby/prk_firmware/releases)

--- a/Tutorial_ja.md
+++ b/Tutorial_ja.md
@@ -6,6 +6,8 @@ Sparkfun Pro Micro RP2040を利用する場合、以下のページも役立ち�
 
 [https://learn.sparkfun.com/tutorials/pro-micro-rp2040-hookup-guide](https://learn.sparkfun.com/tutorials/pro-micro-rp2040-hookup-guide)
 
+その他、利用可能なマイコンボードやキーボードは [[Microcontroller-boards-and-Keyboards]] を参照してください。
+
 ## やってみよう！
 
 - [Releases](https://github.com/picoruby/prk_firmware/releases) から最新のリリースバイナリをダウンロードします。


### PR DESCRIPTION
I'm a newbie to `DIY keyboard`, and I'm very grateful that prk_firmware has led me to build my own `Ruby keyboard`.
Thank you so much for creating the coolest firmware ever!!

Now, at the beginning of the [Tutorial](https://github.com/picoruby/prk_firmware/wiki/Tutorial), I see `Raspberry Pi Pico` and `Sparkfun Pro Micro RP2040`, 
but I wondered what other microcontroller boards can I use? or what kind of keyboards can I use?

I found that [Microcontroller boards and Keyboards](https://github.com/picoruby/prk_firmware/wiki/Microcontroller-boards-and-Keyboards) is already available on the Wiki, 
but I thought it would be easier to understand if it was linked from the Tutorial, so I raised a PR. 
I hope you will consider it.